### PR TITLE
Use md5sum instead of not existing md5 on linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Check deps versions change
         run: |
-          CHECKSUM=$( md5 -r versions.conf | cut -d ' ' -f1 )
+          CHECKSUM=$( md5sum versions.conf | cut -d ' ' -f1 )
           echo "DEPS_CHECKSUM=$CHECKSUM" >> $GITHUB_ENV
 
       - name: Prepare build cache for branch/tag


### PR DESCRIPTION
md5 does not exist / is not installed on Linux by def.

md5sum without `-r` option should return the same.